### PR TITLE
Change img src to relative

### DIFF
--- a/octoprint_PrusaMeshMap/templates/PrusaMeshMap_tab.jinja2
+++ b/octoprint_PrusaMeshMap/templates/PrusaMeshMap_tab.jinja2
@@ -1,3 +1,3 @@
 <button class="btn btn-block control-box" data-bind="enable: controlViewModel.isOperational() && !controlViewModel.isPrinting() && loginStateViewModel.isUser(), click: function() { $root.sendPrusaBedLevel() }">Perform Bed Level and Check</button>
-<img id="PrusaMeshMap-heatmap" src="/plugin/PrusaMeshMap/static/img/heatmap.png" />
+<img id="PrusaMeshMap-heatmap" src="plugin/PrusaMeshMap/static/img/heatmap.png" />
 <button class="btn btn-block control-box" onclick='document.getElementById("PrusaMeshMap-heatmap").src="/plugin/PrusaMeshMap/static/img/heatmap.png?" + new Date().getTime();'>Reload Heatmap Image</button>


### PR DESCRIPTION
This change should make the plugin generate the correct heatmap image URL when OctoPrint is running behind a reverse proxy and its URL is a subdirectory of a domain (e.g. mysite.com/print).